### PR TITLE
libuuid v2.42.1

### DIFF
--- a/.azure-pipelines/azure-pipelines-osx.yml
+++ b/.azure-pipelines/azure-pipelines-osx.yml
@@ -12,10 +12,12 @@ jobs:
         CONFIG: osx_64_
         UPLOAD_PACKAGES: 'True'
         VMIMAGE: macOS-15
+        store_build_artifacts: false
       osx_arm64_:
         CONFIG: osx_arm64_
         UPLOAD_PACKAGES: 'True'
         VMIMAGE: macOS-15
+        store_build_artifacts: false
   timeoutInMinutes: 360
   variables: {}
 

--- a/.github/workflows/conda-build.yml
+++ b/.github/workflows/conda-build.yml
@@ -23,16 +23,19 @@ jobs:
       matrix:
         include:
           - CONFIG: linux_64_
+            STORE_BUILD_ARTIFACTS: False
             UPLOAD_PACKAGES: True
             os: ubuntu
             runs_on: ['ubuntu-latest']
             DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
           - CONFIG: linux_aarch64_
+            STORE_BUILD_ARTIFACTS: False
             UPLOAD_PACKAGES: True
             os: ubuntu
             runs_on: ['ubuntu-latest']
             DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
           - CONFIG: linux_ppc64le_
+            STORE_BUILD_ARTIFACTS: False
             UPLOAD_PACKAGES: True
             os: ubuntu
             runs_on: ['ubuntu-latest']
@@ -109,7 +112,7 @@ jobs:
       env:
         # default value; make it explicit, as it needs to match with artefact
         # generation below. Not configurable for now, can be revisited later
-        CONDA_BLD_DIR: C:\bld
+        CONDA_BLD_PATH: C:\bld
         MINIFORGE_HOME: ${{ contains(runner.arch, 'ARM') && 'C' || 'D' }}:\Miniforge
         PYTHONUNBUFFERED: 1
         CONFIG: ${{ matrix.CONFIG }}

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 # Ignore all files and folders in root
 *
 !/conda-forge.yml
+!.recipe_maintainers.json
 
 # Don't ignore any files/folders if the parent folder is 'un-ignored'
 # This also avoids warnings when adding an already-checked file with an ignored parent.

--- a/pixi.toml
+++ b/pixi.toml
@@ -5,7 +5,7 @@
 
 [workspace]
 name = "libuuid-feedstock"
-version = "3.58.0"  # conda-smithy version used to generate this file
+version = "3.61.2"  # conda-smithy version used to generate this file
 description = "Pixi configuration for conda-forge/libuuid-feedstock"
 authors = ["@conda-forge/libuuid"]
 channels = ["conda-forge"]

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -1,7 +1,7 @@
 schema_version: 1
 
 context:
-  version: "2.42"
+  version: "2.42.1"
 
 package:
   name: libuuid
@@ -10,7 +10,7 @@ package:
 source:
   # use github mirror to make it easier for bot to scrape for new versions
   url: https://github.com/util-linux/util-linux/archive/refs/tags/v${{ version }}.tar.gz
-  sha256: ae5db06b513ac5d42b91e131f26aa8b59da6b623eeb948567cc7a7cb2c13ccb2
+  sha256: 138a3bd9049afa5eeeea73f1e9c0ed7bddf3e55ba4ec29924965a932ec738f01
   patches:
     - darwin_libtoolize.patch
 


### PR DESCRIPTION
Bumps libuuid to util-linux 2.42.1, keeping it in lockstep with the `util-linux` feedstock (which pins `libuuid {{ version }}`).

This is the prerequisite for conda-forge/util-linux-feedstock#54 — that PR's CI currently fails with `Unsatisfiable dependencies: MatchSpec("libuuid=2.42.1")` because no `libuuid 2.42.1` exists on conda-forge.

Checklist:
- [x] Source `sha256` updated for the v2.42.1 tag tarball.
- [x] `darwin_libtoolize.patch` verified to still apply cleanly against 2.42.1.
- [x] Re-rendered with conda-smithy 3.61.2 (separate commit).
- [x] Build number reset to 0 (version bump).

🤖 Generated with [Claude Code](https://claude.com/claude-code)